### PR TITLE
Add Longhorn Raw Block Device Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # dbench
 Benchmark Kubernetes persistent disk volumes with `fio`: Read/write IOPS, bandwidth MB/s and latency.
 
+This REPO is forked from [leeliu/dbench](https://github.com/leeliu/dbench), and is for Longhorn volume raw block device benchmarks.
+
 # Usage
 
-1. Download [dbench.yaml](https://raw.githubusercontent.com/logdna/dbench/master/dbench.yaml) and edit the `storageClassName` to match your Kubernetes provider's Storage Class `kubectl get storageclasses`
-2. Deploy Dbench using: `kubectl apply -f dbench.yaml`
-3. Once deployed, the Dbench Job will:
-    * provision a Persistent Volume of `1000Gi` (default) using `storageClassName: ssd` (default)
+1. Deploy Longhorn [official document](https://longhorn.io/docs/1.0.1/deploy/) and **make sure there is no longhorn volume before this test**.
+2. Download [dbench.yaml](https://raw.githubusercontent.com/longhorn/dbench/longhorn/dbench.yaml)
+3. Deploy Dbench using: `kubectl apply -f dbench.yaml`
+4. Once deployed, the Dbench Job will:
+    * provision a Persistent Volume of `2Gi` (default) using `storageClassName: longhorn` (default)
     * run a series of `fio` tests on the newly provisioned disk
     * currently there are 9 tests, 15s per test - total runtime is ~2.5 minutes
 4. Follow benchmarking progress using: `kubectl logs -f job/dbench` (empty output means the Job not yet created, or `storageClassName` is invalid, see Troubleshooting below)
@@ -24,15 +27,10 @@ Mixed Random Read/Write IOPS: 43.1k/14.4k
 
 ## Notes / Troubleshooting
 
-* If the Persistent Volume Claim is stuck on Pending, it's likely you didn't specify a valid Storage Class. Double check using `kubectl get storageclasses`. Also check that the volume size of `1000Gi` (default) is available for provisioning.
+* If the Persistent Volume Claim is stuck on Pending, it's likely you didn't specify a valid Storage Class. Double check using `kubectl get storageclasses`. Also check that the volume size of `2Gi` (default) is available for provisioning.
 * It can take some time for a Persistent Volume to be Bound and the Kubernetes Dashboard UI will show the Dbench Job as red until the volume is finished provisioning.
-* It's useful to test multiple disk sizes as most cloud providers price IOPS per GB provisioned. So a `4000Gi` volume will perform better than a `1000Gi` volume. Just edit the yaml, `kubectl delete -f dbench.yaml` and run `kubectl apply -f dbench.yaml` again after deprovision/delete completes.
-* A list of all `fio` tests are in [docker-entrypoint.sh](https://github.com/logdna/dbench/blob/master/docker-entrypoint.sh).
-
-## Contributors
-
-* Lee Liu (LogDNA)
-* [Alexis Turpin](https://github.com/alexis-turpin)
+* Uncomment the command in from [dbench.yaml](https://raw.githubusercontent.com/longhorn/dbench/longhorn/dbench.yaml) and then login to the pod and run `/docker-entrypoint.sh fio` directly to debug any issue.
+* A list of all `fio` tests are in [docker-entrypoint.sh](https://raw.githubusercontent.com/longhorn/dbench/longhorn/docker-entrypoint.sh).
 
 ## License
 

--- a/dbench.yaml
+++ b/dbench.yaml
@@ -3,17 +3,13 @@ apiVersion: v1
 metadata:
   name: dbench-pv-claim
 spec:
-  storageClassName: ssd
-  # storageClassName: gp2
-  # storageClassName: local-storage
-  # storageClassName: ibmc-block-bronze
-  # storageClassName: ibmc-block-silver
-  # storageClassName: ibmc-block-gold
+  storageClassName: longhorn
+  volumeMode: Block
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1000Gi
+      storage: 2Gi
 ---
 apiVersion: batch/v1
 kind: Job
@@ -24,22 +20,27 @@ spec:
     spec:
       containers:
       - name: dbench
-        image: logdna/dbench:latest
+        image: longhorn/dbench:latest
+        #image: boknowswiki/dbench:longhorn
         imagePullPolicy: Always
+        securityContext:
+          # Need this for fio be able to invalid the cache
+          privileged: true
+        #command: ["/bin/sh", "-c", "while true; do :; done"]
         env:
-          - name: DBENCH_MOUNTPOINT
-            value: /data
+          #- name: DBENCH_MOUNTPOINT
+          #  value: /data
           # - name: DBENCH_QUICK
           #   value: "yes"
-          # - name: FIO_SIZE
-          #   value: 1G
+          - name: FIO_SIZE
+            value: 1G
           # - name: FIO_OFFSET_INCREMENT
           #   value: 256M
           # - name: FIO_DIRECT
           #   value: "0"
-        volumeMounts:
-        - name: dbench-pv
-          mountPath: /data
+        #volumeMounts:
+        #- name: dbench-pv
+        #  mountPath: /data
       restartPolicy: Never
       volumes:
       - name: dbench-pv

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env sh
 set -e
 
+if [ ! -d "/dev/longhorn" ]; then
+	echo "Failed to find longhorn directory"
+	exit 1
+fi
+
+device_cnt=$(ls /dev/longhorn/ | wc -l)
+
+if [ "$device_cnt" != "1" ]; then
+	echo Failed to find longhorn device
+	exit 2
+fi
+
+device_dir=$(ls /dev/longhorn/)
+device_dir="/dev/longhorn/$device_dir"
+DBENCH_FILENAME=$device_dir
+
+
 if [ -z $DBENCH_MOUNTPOINT ]; then
     DBENCH_MOUNTPOINT=/tmp
 fi
@@ -17,34 +34,34 @@ if [ -z $FIO_DIRECT ]; then
     FIO_DIRECT=1
 fi
 
-echo Working dir: $DBENCH_MOUNTPOINT
+echo Working dir: $DBENCH_FILENAME
 echo
 
 if [ "$1" = 'fio' ]; then
 
     echo Testing Read IOPS...
-    READ_IOPS=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=64 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
+    READ_IOPS=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_iops --filename=$DBENCH_FILENAME --bs=4K --iodepth=64 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
     echo "$READ_IOPS"
     READ_IOPS_VAL=$(echo "$READ_IOPS"|grep -E 'read ?:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
     echo
     echo
 
     echo Testing Write IOPS...
-    WRITE_IOPS=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=64 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
+    WRITE_IOPS=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_iops --filename=$DBENCH_FILENAME --bs=4K --iodepth=64 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
     echo "$WRITE_IOPS"
     WRITE_IOPS_VAL=$(echo "$WRITE_IOPS"|grep -E 'write:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
     echo
     echo
 
     echo Testing Read Bandwidth...
-    READ_BW=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=64 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
+    READ_BW=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_bw --filename=$DBENCH_FILENAME --bs=128K --iodepth=64 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
     echo "$READ_BW"
     READ_BW_VAL=$(echo "$READ_BW"|grep -E 'read ?:'|grep -Eoi 'BW=[0-9GMKiBs/.]+'|cut -d'=' -f2)
     echo
     echo
 
     echo Testing Write Bandwidth...
-    WRITE_BW=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=64 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
+    WRITE_BW=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_bw --filename=$DBENCH_FILENAME --bs=128K --iodepth=64 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
     echo "$WRITE_BW"
     WRITE_BW_VAL=$(echo "$WRITE_BW"|grep -E 'write:'|grep -Eoi 'BW=[0-9GMKiBs/.]+'|cut -d'=' -f2)
     echo
@@ -52,35 +69,35 @@ if [ "$1" = 'fio' ]; then
 
     if [ "$DBENCH_QUICK" == "" ] || [ "$DBENCH_QUICK" == "no" ]; then
         echo Testing Read Latency...
-        READ_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
+        READ_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_FILENAME --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s)
         echo "$READ_LATENCY"
         READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[0-9.]+'|cut -d'=' -f2)
         echo
         echo
 
         echo Testing Write Latency...
-        WRITE_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
+        WRITE_LATENCY=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_FILENAME --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s)
         echo "$WRITE_LATENCY"
         WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[0-9.]+'|cut -d'=' -f2)
         echo
         echo
 
         echo Testing Read Sequential Speed...
-        READ_SEQ=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_seq --filename=$DBENCH_MOUNTPOINT/fiotest --bs=1M --iodepth=16 --size=$FIO_SIZE --readwrite=read --time_based --ramp_time=2s --runtime=15s --thread --numjobs=4 --offset_increment=$FIO_OFFSET_INCREMENT)
+        READ_SEQ=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_seq --filename=$DBENCH_FILENAME --bs=1M --iodepth=16 --size=$FIO_SIZE --readwrite=read --time_based --ramp_time=2s --runtime=15s --thread --numjobs=4 --offset_increment=$FIO_OFFSET_INCREMENT)
         echo "$READ_SEQ"
         READ_SEQ_VAL=$(echo "$READ_SEQ"|grep -E 'READ:'|grep -Eoi '(aggrb|bw)=[0-9GMKiBs/.]+'|cut -d'=' -f2)
         echo
         echo
 
         echo Testing Write Sequential Speed...
-        WRITE_SEQ=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_seq --filename=$DBENCH_MOUNTPOINT/fiotest --bs=1M --iodepth=16 --size=$FIO_SIZE --readwrite=write --time_based --ramp_time=2s --runtime=15s --thread --numjobs=4 --offset_increment=$FIO_OFFSET_INCREMENT)
+        WRITE_SEQ=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_seq --filename=$DBENCH_FILENAME --bs=1M --iodepth=16 --size=$FIO_SIZE --readwrite=write --time_based --ramp_time=2s --runtime=15s --thread --numjobs=4 --offset_increment=$FIO_OFFSET_INCREMENT)
         echo "$WRITE_SEQ"
         WRITE_SEQ_VAL=$(echo "$WRITE_SEQ"|grep -E 'WRITE:'|grep -Eoi '(aggrb|bw)=[0-9GMKiBs/.]+'|cut -d'=' -f2)
         echo
         echo
 
         echo Testing Read/Write Mixed...
-        RW_MIX=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=rw_mix --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4k --iodepth=64 --size=$FIO_SIZE --readwrite=randrw --rwmixread=75 --time_based --ramp_time=2s --runtime=15s)
+        RW_MIX=$(fio --randrepeat=0 --verify=0 --ioengine=libaio --direct=$FIO_DIRECT --gtod_reduce=1 --name=rw_mix --filename=$DBENCH_FILENAME --bs=4k --iodepth=64 --size=$FIO_SIZE --readwrite=randrw --rwmixread=75 --time_based --ramp_time=2s --runtime=15s)
         echo "$RW_MIX"
         RW_MIX_R_IOPS=$(echo "$RW_MIX"|grep -E 'read ?:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
         RW_MIX_W_IOPS=$(echo "$RW_MIX"|grep -E 'write:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
@@ -100,7 +117,6 @@ if [ "$1" = 'fio' ]; then
         echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS/$RW_MIX_W_IOPS"
     fi
 
-    rm $DBENCH_MOUNTPOINT/fiotest
     exit 0
 fi
 


### PR DESCRIPTION
Fio container need to be run with privileged mode to be able to invalid
the cache, and for k8s, if a container is running with privileged mode,
the volumeDevices mapping will be ignored, link is below:

https://github.com/kubernetes/kubernetes/issues/85624

We work around it by list the device name under /dev/longhorn, and pass
it to fio.

https://github.com/longhorn/longhorn/issues/1664

Signed-off-by: Bo Tao <bo.tao@rancher.com>